### PR TITLE
Melhorias em relação as views de listagem no geral

### DIFF
--- a/app/Http/Controllers/AlunoController.php
+++ b/app/Http/Controllers/AlunoController.php
@@ -36,14 +36,10 @@ class AlunoController extends Controller{
 	public function listar (){
 
 		$curso_user = \Auth::user()->curso_id; // curso_id do consultante
+		$nome_curso = \SimuladoENADE\Curso::find($curso_user)->curso_nome;
+        $alunos = \SimuladoENADE\Aluno::where('curso_id', '=', $curso_user)->orderBy('nome')->get();
 
-		$alunos =\SimuladoENADE\Aluno::select('*', \DB::raw('alunos.id as aluno_id'))
-			->join('cursos', 'alunos.curso_id', '=', 'cursos.id') // para exibir o nome do curso
-			->where('curso_id', '=', $curso_user) // para limitar a exibição aos alunos do mesmo curso que o consultante
-			->orderBy('nome') // ordena
-			->get();
-		
-		return view('/AlunoView/listaAluno',['alunos'=> $alunos]);
+		return view('/AlunoView/listaAluno',['alunos'=> $alunos, 'nome_curso' => $nome_curso]);
 
 	}
 

--- a/app/Http/Controllers/CursoController.php
+++ b/app/Http/Controllers/CursoController.php
@@ -31,7 +31,11 @@ class Cursocontroller extends Controller
     }
 
 	public function listar(){
-		$cursos = \SimuladoENADE\Curso::all();
+
+		$cursos =\SimuladoENADE\Curso::select('*', \DB::raw('cursos.id as curso_id'))
+            ->join('ciclos', 'cursos.ciclo_id', '=', 'ciclos.id')
+            ->get();
+
 		return view('/CursoView/listaCursos', ['cursos' => $cursos]);
 
  	}

--- a/app/Http/Controllers/DisciplinaController.php
+++ b/app/Http/Controllers/DisciplinaController.php
@@ -35,11 +35,12 @@ class DisciplinaController extends Controller
     	
     
  	public function listar(){
-        $user = \Auth::user();
-        #dd($user->curso_id);
-		$disciplinas = \SimuladoENADE\Disciplina::where('curso_id', '=', $user->curso_id)->get();
-        $cursos = \SimuladoENADE\Curso::all();
-		return view('/DisciplinaView/listaDisciplinas', ['disciplinas' => $disciplinas]);
+
+        $curso_user = \Auth::user()->curso_id;
+		$nome_curso = \SimuladoENADE\Curso::find($curso_user)->curso_nome;
+        $disciplinas = \SimuladoENADE\Disciplina::where('curso_id', '=', $curso_user)->orderBy('nome')->get();
+
+		return view('/DisciplinaView/listaDisciplinas', ['disciplinas' => $disciplinas, 'nome_curso' => $nome_curso]);
 
  	}   
  	

--- a/app/Http/Controllers/QuestaoController.php
+++ b/app/Http/Controllers/QuestaoController.php
@@ -65,19 +65,24 @@ class QuestaoController extends Controller
 	}
 
 	public function cadastrar(){
+
 		$disciplinas = \SimuladoENADE\Disciplina::where('curso_id', '=', \Auth::user()->curso_id)->get(); 
 		return view('/QuestaoView/cadastrarQuestao', ['disciplinas' => $disciplinas]); 
+		
 	}
 	
 	public function listar(){
 
-		$questao =\SimuladoENADE\Questao::select('*', \DB::raw('questaos.id as qtsid'))
+		$curso_id = \Auth::user()->curso_id;
+		$nome_curso = \SimuladoENADE\Curso::find($curso_id)->curso_nome;
+
+		$questaos =\SimuladoENADE\Questao::select('*', \DB::raw('questaos.id as qtsid'))
 			->join('disciplinas', 'questaos.disciplina_id', '=', 'disciplinas.id')
 			->where('curso_id', '=', \Auth::user()->curso_id)
 			->orderBy('nome')
 			->get();
 
-		return view('/QuestaoView/listaQuestao', ['questaos' => $questao]);
+		return view('/QuestaoView/listaQuestao', ['questaos' => $questaos, 'nome_curso' => $nome_curso]);
 	}
 
 	public function editar(Request $request){

--- a/app/Http/Controllers/QuestaoSimuladoController.php
+++ b/app/Http/Controllers/QuestaoSimuladoController.php
@@ -18,9 +18,12 @@ class QuestaoSimuladoController extends Controller{
 
         $questaos = \DB::table('questao_simulados')
             ->join('questaos', 'questao_simulados.questao_id', '=', 'questaos.id')
-            ->select('questaos.*', 'questao_simulados.*')
+            ->join('disciplinas', 'questaos.disciplina_id', '=', 'disciplinas.id')
+            ->select('questaos.*', 'questao_simulados.*', 'disciplinas.nome as disc_nome')
             ->where('simulado_id', '=', $request->id)
             ->get();
+
+        
 
         return view('/SimuladoView/montarSimulado',['disciplinas' => $disciplinas, 'questaos' => $questaos, 'simulado_id'=> $request->id]);     
      

--- a/app/Http/Controllers/SimuladoController.php
+++ b/app/Http/Controllers/SimuladoController.php
@@ -47,8 +47,15 @@ class SimuladoController extends Controller{
 	public function listar(){
 		
 		$curso_id = \Auth::user()->curso_id;
-		$simulados = \SimuladoENADE\Simulado::where('curso_id', '=', $curso_id)->get();
-		return view('/SimuladoView/listaSimulado', ['simulados' => $simulados]);
+		$nome_curso = \SimuladoENADE\Curso::find($curso_id)->curso_nome;
+
+		$simulados =\SimuladoENADE\Simulado::select('*', \DB::raw('simulados.id as sim_id'))
+			->join('usuarios', 'simulados.usuario_id', '=', 'usuarios.id')
+			->where('simulados.curso_id', '=', $curso_id)
+			->orderBy('descricao_simulado')
+			->get();
+
+		return view('/SimuladoView/listaSimulado', ['simulados' => $simulados, 'nome_curso' => $nome_curso]);
 
 	}
 
@@ -57,6 +64,7 @@ class SimuladoController extends Controller{
 		$simulado= \SimuladoENADE\Simulado::find($request->id);
 		$cursos = \SimuladoENADE\Curso::all();
 		$usuarios = \SimuladoENADE\Usuario::all();
+
 		return view ('/SimuladoView/editarSimulado', ['simulado' => $simulado, 'cursos' => $cursos, 'usuarios' => $usuarios]);
 
 	}
@@ -64,6 +72,7 @@ class SimuladoController extends Controller{
 	public function atualizar(Request $request){
 		
 		try{
+			
 			SimuladoValidator::Validate($request->all());
 
 			$simulado = \SimuladoENADE\Simulado::find($request->id);
@@ -79,16 +88,17 @@ class SimuladoController extends Controller{
 
 	public function listaSimuladoAluno(Request $request){
 		
-		$curso = \Auth::guard('aluno')->user()->curso_id;
-		$simulados = \SimuladoENADE\Simulado::where('curso_id', '=', $curso)->get();
-		return view('/SimuladoView/listaSimuladoAluno', ['simulados' => $simulados]);
+		$curso_id = \Auth::guard('aluno')->user()->curso_id;
+		$nome_curso = \SimuladoENADE\Curso::find($curso_id)->curso_nome;
+		$simulados = \SimuladoENADE\Simulado::where('curso_id', '=', $curso_id)->get();
+		
+		return view('/SimuladoView/listaSimuladoAluno', ['simulados' => $simulados, 'nome_curso' => $nome_curso]);
 
 	}
 
 	public function startSimulado(Request $request)	{
 		
 		$simulado = \SimuladoENADE\Simulado::find($request->id);
-
 		$questaos = self::getQuestoes($simulado);
 		
 		if (empty($questaos))

--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -60,12 +60,13 @@ class Usuariocontroller extends Controller
 			}
 
 		} catch(ValidationException $ex){
+			
 			$user =  \Auth::user()->tipousuario_id;
-			if($user == 4){
+			if($user == 4)
 				return redirect("/cadastrar/usuario")->withErrors($ex->getValidator())->withInput();
-			} elseif($user == 2){
+			elseif($user == 2)
 				return redirect("/cadastrar/professor")->withErrors($ex->getValidator())->withInput();
-			}	
+
 		}
 	}
 
@@ -75,11 +76,11 @@ class Usuariocontroller extends Controller
 		$cursos = \SimuladoENADE\Curso::all();
 		$tipos_usuario = \SimuladoENADE\Tipousuario::all(); // Tem q retirar aluno, pois está em outra tabela
 
-		if($user == 4){
+		if($user == 4)
 			return view('/UsuarioView/cadastrarUsuario',['cursos' => $cursos, 'tipos_usuario' => $tipos_usuario]);
-		} elseif($user == 2){
+		elseif($user == 2)
 			return view('/UsuarioView/cadastrarProfessor',['cursos' => $cursos, 'tipos_usuario' => $tipos_usuario]);
-		}
+		
 	}
 
 	public function listar (Request $request) {
@@ -105,16 +106,17 @@ class Usuariocontroller extends Controller
 		} elseif($tipo_usuario == 2){
 
 			// Apenas usuarios do tipo 3 (professores) e do mesmo curso do coord
-			$usuarios =\SimuladoENADE\Usuario::select('*', \DB::raw('usuarios.id as userid'))
-				->join('cursos', 'usuarios.curso_id', '=', 'cursos.id') // para exibir o nome do curso
-				->where('curso_id', '=', $curso_id) // para limitar a exibição aos usuarios do mesmo curso que o consultante
-				->where('tipousuario_id','=',3) // apenas professores
-				->orderBy('nome') // ordena
-				->get();
+        	$usuarios = \SimuladoENADE\Usuario::where('curso_id', '=', $curso_id)
+        		->where('tipousuario_id','=',3) // apenas professores
+        		->orderBy('nome')
+        		->get();
+        		
+			$nome_curso = \SimuladoENADE\Curso::find($curso_id)->curso_nome;
 
-			return view('/UsuarioView/ListaProfessor',['usuarios' => $usuarios]); 
+			return view('/UsuarioView/ListaProfessor',['usuarios' => $usuarios, 'nome_curso' => $nome_curso]); 
 			
 		}
+
 	}
 
 	public function editar(Request $request) {

--- a/app/Questao.php
+++ b/app/Questao.php
@@ -4,10 +4,8 @@ namespace SimuladoENADE;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Questao extends Model
-
-{
-    //
+class Questao extends Model {
+    
     public function disciplina(){
     	return $this->hasOne('SimuladoENADE\Disciplina');
     }
@@ -16,7 +14,6 @@ class Questao extends Model
 						   'alternativa_correta', 
 						   'dificuldade',
                         'disciplina_id'];
-
 
     public static $rules = [
     	'enunciado' => 'required|min:10',
@@ -31,5 +28,19 @@ class Questao extends Model
     	'alternativa_correta.max' => 'Este campo de ter no max 1 caracteres',
         'disciplina_id.integer' => 'o id deve ser inteiro'
     ];
+
+    public function getDificuldadeAttribute($dificuldade){
+
+        switch ($dificuldade) {
+            case 1:
+                return "Fácil";
+            case 2:
+                return "Médio";
+            case 3:
+                return "Difícil";
+        }
+
+        return null;
+    }
 
 }

--- a/resources/views/AlunoView/listaAluno.blade.php
+++ b/resources/views/AlunoView/listaAluno.blade.php
@@ -3,28 +3,25 @@
     
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 		
-		<h1>Alunos cadastrados</h1><br>
+		<h1 class="text-center">Alunos Cadastrados</h1>
+		<h2 class="text-center">{{$nome_curso}}</h2><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
-					<th>ID</th>
 					<th>Nome</th>
 					<th>CPF</th>
-					<th>Email</th>
-					<th>Curso</th>
+					<th>E-mail</th>
 					<th>Funções</th>
 				</tr>
 			</thead>
 			<tbody>
 				@foreach($alunos as $aluno)
 					<tr>
-						<td>{{$aluno->aluno_id}}</td>
 						<td>{{$aluno->nome}}</td>
 						<td>{{$aluno->cpf}}</td>
 						<td>{{$aluno->email}}</td>
-						<td>{{$aluno->curso_nome}}</td>
 						<td> 
-							<a href="{{route('edit_aluno', ['id' => $aluno->aluno_id])}}">Editar</a> - <a href="{{route('delete_aluno', ['id' => $aluno->aluno_id])}}">Remover</a>
+							<a href="{{route('edit_aluno', ['id' => $aluno->id])}}">Editar</a> - <a href="{{route('delete_aluno', ['id' => $aluno->id])}}">Remover</a>
 						</td>
 					</tr>
 				@endforeach

--- a/resources/views/CicloView/listaCiclo.blade.php
+++ b/resources/views/CicloView/listaCiclo.blade.php
@@ -3,7 +3,7 @@
 
 	<div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 
-		<h1>Ciclos</h1><br>
+		<h1 class="text-center">Ciclos</h1><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>

--- a/resources/views/CursoView/listaCursos.blade.php
+++ b/resources/views/CursoView/listaCursos.blade.php
@@ -2,13 +2,13 @@
 @section('content')
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 
-		<h1> Cursos </h1><br>
+		<h1 class="text-center"> Cursos </h1><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
 					<th>Id</th>
 					<th>Nome do Curso</th>
-					<th>ID do Ciclo</th>
+					<th>Ciclo</th>
 					<th>Unidade</th>
 					<th>Funções</th>
 				</tr>
@@ -16,13 +16,13 @@
 			<tbody>
 				@foreach ($cursos as $curso)
 					<tr>
-						<td>{{$curso->id}}</td>
+						<td>{{$curso->curso_id}}</td>
 						<td>{{$curso->curso_nome}}</td>
-						<td>{{$curso->ciclo_id}}</td>
+						<td>{{$curso->tipo_ciclo}}</td>
 						<td>{{$curso->unidade->nome}}</td>
 						<td> 
-							<a href="{{route('edit_curso',['id'=>$curso->id])}}">Editar</a> - 
-							<a href="{{route('delete_curso',['id'=>$curso->id])}}">Remover</a>
+							<a href="{{route('edit_curso',['id'=>$curso->curso_id])}}">Editar</a> - 
+							<a href="{{route('delete_curso',['id'=>$curso->curso_id])}}">Remover</a>
 						</td>
 					</tr>
 				@endforeach

--- a/resources/views/DisciplinaView/listaDisciplinas.blade.php
+++ b/resources/views/DisciplinaView/listaDisciplinas.blade.php
@@ -3,22 +3,19 @@
 
 	<div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 	    
-		<h1>Lista de Disciplinas</h1><br>
+		<h1 class="text-center">Disciplinas Cadastradas</h1>
+		<h2 class="text-center">{{$nome_curso}}</h2><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
-					<th>ID</th>
-					<th>Nome</th>
-					<th>Curso</th>
+					<th style="width: 70%">Nome</th>
 					<th>Funções</th>
 				</tr>
 			</thead>
 			<tbody>
 				@foreach ($disciplinas as $disciplina)
 					<tr>
-						<td>{{$disciplina->id}}</td>
-						<td>{{$disciplina->nome}}</td>
-						<td>{{$disciplina->curso_id}}</td>
+						<td style="">{{$disciplina->nome}}</td>
 						<td> 
 							<a href="{{route('edit_disciplina',['id'=>$disciplina->id])}}">Editar</a> -
 							<a href="{{route('delete_disciplina',['id'=>$disciplina->id])}}">Remover</a>

--- a/resources/views/QuestaoView/listaQuestao.blade.php
+++ b/resources/views/QuestaoView/listaQuestao.blade.php
@@ -3,23 +3,20 @@
     
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
     
-		<h1>Questões Cadastradas</h1><br>
+		<h1 class="text-center">Questões Cadastradas</h1>
+		<h2 class="text-center">{{$nome_curso}}</h2><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
-					<th>Numº Questao</th>
 					<th>Enunciado</th>
-					<th>Nivel Questão</th>
-					<th>ID da Disciplina</th>
-					<th>Funções</th>
+					<th>Nível</th>
+					<th>Disciplina</th>
+					<th style="width: 15%">Funções</th>
 				</tr>
 			</thead>
 			<tbody>
-				<!-- Verificar se o contador nesse local fere o modelo MVC -->
-				<p type="hidden" value="{{ $x = 1 }}"></p>
 				@foreach($questaos as $questao)
 					<tr>
-						<td>{{$x++}}</td> 
 						<td>{{preg_replace('/<[^>]*>|[&;]/', '', $questao->enunciado) }}</td>
 						<td>{{$questao->dificuldade}}</td>
 						<td>{{$questao->nome}}</td>

--- a/resources/views/SimuladoView/listaSimulado.blade.php
+++ b/resources/views/SimuladoView/listaSimulado.blade.php
@@ -3,28 +3,25 @@
 
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
     
-		<h1>Simulados Cadastrados</h1><br>
+		<h1 class="text-center">Simulados Cadastrados</h1>
+		<h2 class="text-center">{{$nome_curso}}</h2><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
-					<th>#</th>
 					<th>Descrição</th>
 					<th>Criado por</th>
-					<th>Curso</th>
-					<th>Funções</th>
+					<th style="width: 20%">Funções</th>
 				</tr>
 			</thead>
 			<tbody>
 				@foreach ($simulados as $simulado)
 					<tr>
-						<td>{{$simulado->id}}</td>
 						<td>{{$simulado->descricao_simulado}}</td>
-						<td>{{$simulado->usuario_id}}</td>
-						<td>{{$simulado->curso_id}}</td>
+						<td>{{$simulado->nome}}</td>
 						<td>
-							<a href="{{route('edit_simulado', ['id'=>$simulado->id])}}">Editar</a> -
-							<a href="{{route('delete_simulado', ['id'=>$simulado->id])}}">Remover</a> - 
-							<a href="{{route('set_simulado', ['id'=>$simulado->id])}}">Montar</a>
+							<a href="{{route('edit_simulado', ['id'=>$simulado->sim_id])}}">Editar</a> -
+							<a href="{{route('delete_simulado', ['id'=>$simulado->sim_id])}}">Remover</a> - 
+							<a href="{{route('set_simulado', ['id'=>$simulado->sim_id])}}">Montar</a>
 						</td>
 					</tr>
 				@endforeach

--- a/resources/views/SimuladoView/listaSimuladoAluno.blade.php
+++ b/resources/views/SimuladoView/listaSimuladoAluno.blade.php
@@ -2,7 +2,8 @@
 @section('content')
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 
-		<h1> Simulados disponíveis </h1><br>
+		<h1 class="text-center"> Simulados disponíveis </h1>
+		<h2 class="text-center">{{$nome_curso}}</h2><br>
 
 		<table class="table table-hover">
 	 		<thead>

--- a/resources/views/SimuladoView/montarSimulado.blade.php
+++ b/resources/views/SimuladoView/montarSimulado.blade.php
@@ -61,10 +61,10 @@
 
 			<thead>
 				<tr>
-					<th>Numº Questao</th>
+					<th>Cód. Questão</th>
 					<th>Enunciado</th>
-					<th>Nivel Questão</th>
-					<th>ID da Disciplina</th>
+					<th>Nível</th>
+					<th>Disciplina</th>
 					<th>Funções</th>
 				</tr>
 			</thead>
@@ -75,15 +75,15 @@
 							<td>{{$qst->id}}</td>
 							<td>{{  preg_replace('/<[^>]*>|[&;]/', '', $qst->enunciado) }}</td>
 							<td>
-								@if($qst->dificuldade  == 1)
+								@if($qst->dificuldade == 1)
 									Fácil
-								@elseif($qst->dificuldade  == 2)
+								@elseif($qst->dificuldade == 2)
 									Médio
 								@else
 									Difícil
 								@endif
 							</td>
-							<td>{{$qst->disciplina_id}}</td>
+							<td>{{$qst->disc_nome}}</td>
 							<td><a href="{{route('remove_qst_simulado', ['sim_qst_id'=>$qst->id])}}">Remover</a></td>
 						</tr>
 					@endforeach

--- a/resources/views/UsuarioView/ListaProfessor.blade.php
+++ b/resources/views/UsuarioView/ListaProfessor.blade.php
@@ -3,29 +3,26 @@
     
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 		
-		<h1>Professores cadastrados</h1><br>
+		<h1 class="text-center">Professores Cadastrados</h1>
+		<h2 class="text-center">{{$nome_curso}}</h2><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
-					<th>ID</th>
 					<th>Nome</th>
 					<th>CPF</th>
-					<th>Email</th>
-					<th>Curso</th>
+					<th>E-mail</th>
 					<th>Funções</th>
 				</tr>
 			</thead>
 			<tbody>
 				@foreach($usuarios as $usuario)
 					<tr>
-						<td>{{$usuario->userid}}</td>
 						<td>{{$usuario->nome}}</td>
 						<td>{{$usuario->cpf}}</td>
 						<td>{{$usuario->email}}</td>
-						<td>{{$usuario->curso_nome}}</td>
 						<td> 
-							<a href="{{route('edit_professor',['id'=>$usuario->userid])}}">Editar</a> - 
-							<a href="{{route('delete_professor',['id'=>$usuario->userid])}}">Remover</a>
+							<a href="{{route('edit_professor',['id'=>$usuario->id])}}">Editar</a> - 
+							<a href="{{route('delete_professor',['id'=>$usuario->id])}}">Remover</a>
 						</td>
 					</tr>
 				@endforeach

--- a/resources/views/UsuarioView/ListaUsuario.blade.php
+++ b/resources/views/UsuarioView/ListaUsuario.blade.php
@@ -3,15 +3,14 @@
 
     <div class="shadow p-4 mb-5 bg-white rounded container-fluid" style="overflow-x: auto;">
 	
-		<h1>Usuários Cadastrados</h1><br>
-		
+		<h1 class="text-center">Usuários Cadastrados</h1><br>
 		<table class="table table-hover">
 	 		<thead>
 				<tr>
 					<th>Nome</th>
 					<th>Tipo de usuário</th>
 					<th>CPF</th>
-					<th>Email</th>
+					<th>E-mail</th>
 					<th>Curso</th>
 					<th>Funções</th>
 				</tr>


### PR DESCRIPTION
Algumas das melhorias feitas: 
- Retirado o ID e os códigos de disciplinas de todas as listagens, além de organizar os itens da lista em ordem alfabética;
- Padronizado os títulos, todos com palavras capitalizadas e centralizados
- Em "Nível da questão" substituído os números por palavras ("Fácil", "Difícil", etc);
- Em "Cadastrar Simulado", foi alinhado à esquerda as caixas de texto e títulos;
- Erros de acentuação
